### PR TITLE
Fix regex for Gemini JSON extraction

### DIFF
--- a/utils/util.py
+++ b/utils/util.py
@@ -18,7 +18,7 @@ def correct_name(scanned: str) -> str:
 
 
 def parse_gemini_output(raw_text: str) -> dict:
-    m = re.search(r'(\{.*\})', raw_text, re.DOTALL)
+    m = re.search(r'(\{.*?\})', raw_text, re.DOTALL)
     if not m:
         raise ValueError("Không tìm thấy JSON trong đầu ra của Gemini")
     return json.loads(m.group(1))


### PR DESCRIPTION
## Summary
- tweak regex in `parse_gemini_output` so it doesn't overmatch

## Testing
- `python -m py_compile utils/util.py`

------
https://chatgpt.com/codex/tasks/task_e_683fc0a6e400832daf4a49cf341b3d26