### PR TITLE
Fix docker tag in publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,4 +37,4 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/orc-api:1.0
+            ${{ secrets.DOCKERHUB_USERNAME }}/ocr-api:1.0


### PR DESCRIPTION
## Summary
- correct the Docker tag name to `ocr-api:1.0` in Docker publish workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684060799cd4832d92efdf3403cf77a0